### PR TITLE
Fix runtime error

### DIFF
--- a/sxgeo.go
+++ b/sxgeo.go
@@ -464,7 +464,6 @@ func ToMemory(f *bytes.Reader) (bool, error) {
 	return true, nil
 }
 
-
 // ReadDBToMemory Reads the whole DB to the memory
 func ReadDBToMemory(path string) (bool, error) {
 	f, err := os.Open(path)
@@ -679,6 +678,14 @@ func parseFullCity(seek uint32) (*Full, error) {
 			return nil, fmt.Errorf("cannot read region data")
 		}
 
+		if r, ok := region["id"]; ok {
+			if r == nil {
+				return nil, fmt.Errorf("region data is nil")
+			}
+		} else {
+			return nil, fmt.Errorf("region data not found")
+		}
+
 		full.Region = &Region{
 			ID:     int((region["id"]).(uint32)),
 			ISO:    fmt.Sprintf("%s", region["iso"]),
@@ -690,6 +697,15 @@ func parseFullCity(seek uint32) (*Full, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to read country")
 		}
+
+		if c, ok := country["id"]; ok {
+			if c == nil {
+				return nil, fmt.Errorf("country data is nil")
+			}
+		} else {
+			return nil, fmt.Errorf("country data not found")
+		}
+
 		full.Country = &Country{
 			ID:     country["id"].(uint8),
 			ISO:    fmt.Sprintf("%s", country["iso"]),
@@ -705,8 +721,14 @@ func readData(seek uint32, max uint16, packType int) (map[string]interface{}, er
 	var raw []byte
 	if (seek > 0) && (max > 0) {
 		if packType == 1 {
+			if len(Regions) < int(seek+uint32(max)) {
+				return nil, fmt.Errorf("cannot unpack region")
+			}
 			raw = Regions[seek : seek+uint32(max)]
 		} else {
+			if len(Cities) < int(seek+uint32(max)) {
+				return nil, fmt.Errorf("cannot unpack city")
+			}
 			raw = Cities[seek : seek+uint32(max)]
 		}
 	}

--- a/sxgeo.go
+++ b/sxgeo.go
@@ -678,12 +678,8 @@ func parseFullCity(seek uint32) (*Full, error) {
 			return nil, fmt.Errorf("cannot read region data")
 		}
 
-		if r, ok := region["id"]; ok {
-			if r == nil {
-				return nil, fmt.Errorf("region data is nil")
-			}
-		} else {
-			return nil, fmt.Errorf("region data not found")
+		if r := region["id"]; r == nil {
+			return nil, fmt.Errorf("region data is nil")
 		}
 
 		full.Region = &Region{
@@ -698,12 +694,8 @@ func parseFullCity(seek uint32) (*Full, error) {
 			return nil, fmt.Errorf("failed to read country")
 		}
 
-		if c, ok := country["id"]; ok {
-			if c == nil {
-				return nil, fmt.Errorf("country data is nil")
-			}
-		} else {
-			return nil, fmt.Errorf("country data not found")
+		if c := country["id"]; c == nil {
+			return nil, fmt.Errorf("country data is nil")
 		}
 
 		full.Country = &Country{

--- a/sxgeo_test.go
+++ b/sxgeo_test.go
@@ -44,13 +44,20 @@ func TestGetCityFull2(t *testing.T) {
 	}
 }
 
-func TestGetCityFull(t *testing.T) {
-	SetEndian(LITTLE)
-	_, err := ReadDBToMemory(path)
+func TestReadDBToMemory(t *testing.T) {
+	bo, err := DetectEndian()
 	if err != nil {
 		t.Fatalf("%s %v", path, err)
 	}
+	SetEndian(bo == binary.LittleEndian)
 
+	_, err = ReadDBToMemory(path)
+	if err != nil {
+		t.Fatalf("%s %v", path, err)
+	}
+}
+
+func TestGetCityFull(t *testing.T) {
 	// более-менее валидные адреса можно взять с https://www.4it.me/getlistip?cityid=5138
 	tcs := []string{
 		"188.255.70.88",
@@ -90,6 +97,26 @@ func TestGetCityFull(t *testing.T) {
 
 		fmt.Printf("%s\n", enc)
 		//os.Exit(0)
+	}
+}
+
+func TestGetCityFullFail(t *testing.T) {
+	testCases := []struct {
+		ip   string
+		want string
+	}{
+		{"94.43.39.192", "region data is nil"},
+		{"212.58.114.163", "region data is nil"},
+		{"5.152.111.87", "region data is nil"},
+		{"83.97.109.147", "cannot read country data"},
+		{"5.59.146.102", "cannot read country data"},
+		{"77.232.146.61", "cannot read country data"},
+	}
+	for _, tc := range testCases {
+		_, err := GetCityFull(tc.ip)
+		if err == nil {
+			t.Fatalf("loopback ip should be detected")
+		}
 	}
 }
 


### PR DESCRIPTION
panic "interface conversion: interface {} is nil, not uint32"
    github.com/barsuk/sxgeo.parseFullCity(0x165490)
    \tgithub.com/barsuk/sxgeo@v0.0.2-beta.1/sxgeo.go:683 +0xba5
    github.com/barsuk/sxgeo.GetCityFull({0xc0038b8bf0?, 0x10?})
    \tgithub.com/barsuk/sxgeo@v0.0.2-beta.1/sxgeo.go:626 +0x2e
    
panic "runtime error: slice bounds out of range [:2686995] with capacity 2683640"
    github.com/barsuk/sxgeo.readData(0x1?, 0x0?, 0x2049cd002049cd?)
    \tgithub.com/barsuk/sxgeo@v0.0.2-beta.1/sxgeo.go:710 +0x277
    github.com/barsuk/sxgeo.parseFullCity(0x290a79)
    \tgithub.com/barsuk/sxgeo@v0.0.2-beta.1/sxgeo.go:658 +0x357
    github.com/barsuk/sxgeo.GetCityFull({0xc00339bc10?, 0x10?})
    \tgithub.com/barsuk/sxgeo@v0.0.2-beta.1/sxgeo.go:626 +0x2e
